### PR TITLE
fix cooperatives scraper duplicate key error

### DIFF
--- a/budgetkey_data_pipelines/pipelines/entities/cooperatives/cooperatives_scraper.py
+++ b/budgetkey_data_pipelines/pipelines/entities/cooperatives/cooperatives_scraper.py
@@ -59,7 +59,7 @@ class CooperativesScraper(object):
     def get_resource_descriptor(self, resource_name):
         return {"name": resource_name,
                 "path": resource_name+".csv",
-                "schema": {"fields": [{'name': 'id', 'type': 'integer'},
+                "schema": {"fields": [{'name': 'id', 'type': 'string'},
                                       {'name': 'name', 'type': 'string'},
                                       {'name': 'registration_date', 'type': 'datetime'},
                                       {'name': 'phone', 'type': 'string'},


### PR DESCRIPTION
changed id field type from integer to string

**need to update DB schema / drop the existing cooperatives table**

fixes #58 