### PR TITLE
geocode: remove dependency on entities/all pipeline, added load_sql_table processor

### DIFF
--- a/budgetkey_data_pipelines/pipelines/entities/pipeline-spec.yaml
+++ b/budgetkey_data_pipelines/pipelines/entities/pipeline-spec.yaml
@@ -192,15 +192,15 @@ entities:
         out-path: /var/datapackages/entities/scored
 
 geocode:
-  dependencies:
-    - pipeline: ./entities/all
+  schedule:
+    crontab: "0 0 * * *"
   pipeline:
-    - run: add_sql_resource
+    - run: load_sql_table
       parameters:
-        datapackage: /var/datapackages/entities/all/datapackage.json
-        resource: entities
         table: entities
-    - run: stream_remote_resources
+        columns:
+          id:
+          details:
     - run: geocode_entities
       parameters:
         input-resource: entities

--- a/budgetkey_data_pipelines/processors/load_sql_table.py
+++ b/budgetkey_data_pipelines/processors/load_sql_table.py
@@ -1,0 +1,52 @@
+from datapackage_pipelines.wrapper import ingest, spew
+from itertools import chain
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine, MetaData
+import os, logging
+
+
+parameters, datapackage, resources = ingest()
+
+
+def initialize_db_session():
+    connection_string = os.environ.get("DPP_DB_ENGINE")
+    assert connection_string is not None, \
+        "Couldn't connect to DB - " \
+        "Please set your '%s' environment variable" % "DPP_DB_ENGINE"
+    engine = create_engine(connection_string)
+    return sessionmaker(bind=engine)()
+
+
+def get_resource():
+    session = initialize_db_session()
+    meta = MetaData(bind=session.connection())
+    meta.reflect()
+    table = meta.tables.get(parameters["table"])
+    if table is None:
+        logging.warning("table does not exist '{}'".format(parameters["table"]))
+    else:
+        query_args = []
+        for column_name, column_params in parameters["columns"].items():
+            if not hasattr(table.c, column_name):
+                raise Exception("missing column in table: {} / {}".format(parameters["table"], column_name))
+            else:
+                query_args.append(getattr(table.c, column_name))
+        for row in session.query(*query_args).all():
+            yield {column_name: getattr(row, column_name)
+                   for column_name, column_params
+                   in parameters["columns"].items()}
+
+
+def get_schema():
+    fields = []
+    for column_name, column_params in parameters["columns"].items():
+        fields.append({"name": column_name, "type": "string"})
+    return {"fields": fields}
+
+
+datapackage["resources"].append({"name": parameters["table"],
+                                 "path": parameters["table"]+".csv",
+                                 "schema": get_schema()})
+
+
+spew(datapackage, chain(resources, [get_resource()]))


### PR DESCRIPTION
* entities/geocode pipeline: removed dependency on entities/all pipeline, instead running on schedule - daily
   * this pipeline compares location strings and only makes http calls when needed - so it should be fine to run daily, even if there weren't any changes in entities
* added load_sql_table processor - which is used by geocode pipeline to remove the dependency on entities/all pipeline
  * this dependency was needed to use the load_sql_resource processor - and was really needed just to get the table schema
  * geocode processor doesn't care about the schema - it just needs id and location strings from DB

related issue: #51 