### PR TITLE
Finalize indexing of date ranges

### DIFF
--- a/datapackage_pipelines_budgetkey/generator.py
+++ b/datapackage_pipelines_budgetkey/generator.py
@@ -106,6 +106,7 @@ class Generator(GeneratorBase):
                     history_steps.extend(
                         cls.history_steps(doc_type, key_fields, kh['fields'], kh.get('key'))
                     )
+                date_range_parameters = parameters.get('date-range', {})
 
                 pipeline_steps = steps(*[
                     ('add_metadata', {
@@ -143,6 +144,7 @@ class Generator(GeneratorBase):
                     ('add_page_title', {
                         'page-title-pattern': page_title_pattern
                     }),
+                    ('add_date_range', date_range_parameters),
                     ('dump_to_es', {
                         'indexes': {
                             'budgetkey': [

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/processed/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/processed/pipeline-spec.yaml
@@ -200,7 +200,6 @@ national-budget-changes-aggregated:
           pending:
             es:itemType: boolean
           year:
-            es:time-range: year
 #    - run: sample
 #      parameters:
 #        resource: national-budget-changes

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/processed/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/processed/pipeline-spec.yaml
@@ -199,7 +199,6 @@ national-budget-changes-aggregated:
             es:itemType: date
           pending:
             es:itemType: boolean
-          year:
 #    - run: sample
 #      parameters:
 #        resource: national-budget-changes

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/processed/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/processed/pipeline-spec.yaml
@@ -384,7 +384,6 @@ connected-national-budgets:
     - run: set_types
       parameters:
         types:
-          year:
           title:
             es:title: true
           admin_cls_code_0:

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/processed/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/processed/pipeline-spec.yaml
@@ -385,7 +385,6 @@ connected-national-budgets:
       parameters:
         types:
           year:
-            es:time-range: year
           title:
             es:title: true
           admin_cls_code_0:

--- a/datapackage_pipelines_budgetkey/pipelines/budgetkey/elasticsearch/add_date_range.py
+++ b/datapackage_pipelines_budgetkey/pipelines/budgetkey/elasticsearch/add_date_range.py
@@ -1,0 +1,60 @@
+from datapackage_pipelines.wrapper import ingest, spew
+from functools import partial
+
+
+parameters, dp, res_iter = ingest()
+
+
+def get_no_date_range(row):
+    return '1900-01-01', '2100-01-01', []
+
+
+def get_year_date_range(field, row):
+    year = row[field]
+    return '{}-01-01'.format(year), '{}-12-31'.format(year), ["{}-{:0>2}".format(year, i) for i in range(1,13)]
+
+
+def get_date_range(from_field, to_field, row):
+    if not row[from_field] and not row[to_field]:
+        return get_no_date_range(row)
+    elif not row[from_field]:
+        return row[to_field], row[to_field], [row[to_field].strftime('%Y-%m')]
+    elif not row[to_field]:
+        return row[from_field], row[from_field], [row[from_field].strftime('%Y-%m')]
+    else:
+        months = []
+        for year in range(row[from_field].year, row[to_field].year+1):
+            from_month = row[from_field].month if year == row[from_field].year else 1
+            to_month = row[to_field].month if year == row[to_field].year else 12
+            for month in range(from_month, to_month+1):
+                months.append('{}-{}'.format(year, month))
+        return row[from_field], row[to_field], months
+
+
+get_date_range_func = {
+    'no-date-range': get_no_date_range,
+    'year': partial(get_year_date_range, parameters.get('field')),
+    'date-range': partial(get_date_range, parameters.get('from-field'), parameters.get('to-field'))
+}[parameters.get('type', 'no-date-range')]
+
+
+def process_resource(res):
+    for row in res:
+        row['__date_range_from'], row['__date_range_to'], row['__date_range_months'] = get_date_range_func(row)
+        yield row
+
+
+def process_resources(res_iter_):
+    first = next(res_iter_)
+    yield process_resource(first)
+    yield from res_iter_
+
+
+dp['resources'][0]['schema']['fields'] += [
+    {'name': '__date_range_from', 'type': 'date'},
+    {'name': '__date_range_to', 'type': 'date'},
+    {'name': '__date_range_months', 'type': 'array', 'es:itemType': 'string', 'es:keyword': True},
+]
+
+
+spew(dp, process_resources(res_iter))

--- a/datapackage_pipelines_budgetkey/pipelines/budgetkey/elasticsearch/budgetkey.source-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/budgetkey/elasticsearch/budgetkey.source-spec.yaml
@@ -20,6 +20,9 @@ budget:
   document-steps:
     - run: make_budget_charts
     - run: add_redirects_for_connected_items
+  date-range:
+    type: year
+    field: year
 
 national-budget-changes:
   kind: indexer
@@ -34,6 +37,9 @@ national-budget-changes:
       key: pending
       fields: 
         - is_pending
+  date-range:
+    type: year
+    field: year
 
 entities:
   kind: indexer
@@ -71,8 +77,12 @@ contract-spending:
         source-fields:
           - purpose
         target-field: semantic-tags
-          
-  
+  date-range:
+    type: date-range
+    from-field: order_date
+    to-field: end_date
+
+
 supports:
   kind: indexer
   revision: 7
@@ -91,6 +101,9 @@ supports:
         - amount_total
         - last_payment_year
         - last_payment_amount
+  date-range:
+    type: year
+    field: year_requested
 
 
 tenders:
@@ -118,6 +131,10 @@ tenders:
           - page_title
           - reason
         target-field: semantic-tags
+  date-range:
+    type: date-range
+    from-field: start_date
+    to-field: end_date
 
 people:
   kind: indexer

--- a/datapackage_pipelines_budgetkey/pipelines/procurement/spending/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/procurement/spending/pipeline-spec.yaml
@@ -299,9 +299,7 @@ latest-contract-spending:
           order_date:
             type: date
           end_date:
-            es:time-range: to
           order_date:
-            es:time-range: from
           buyer_description:
             es:itemType: string
           exemption_reason:

--- a/datapackage_pipelines_budgetkey/pipelines/procurement/spending/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/procurement/spending/pipeline-spec.yaml
@@ -298,8 +298,6 @@ latest-contract-spending:
             type: date
           order_date:
             type: date
-          end_date:
-          order_date:
           buyer_description:
             es:itemType: string
           exemption_reason:

--- a/datapackage_pipelines_budgetkey/pipelines/procurement/tenders/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/procurement/tenders/pipeline-spec.yaml
@@ -195,8 +195,6 @@ processed:
     - run: set_types
       parameters:
         types:
-          end_date:
-          start_date:
           description:
             es:title: true
           documents:

--- a/datapackage_pipelines_budgetkey/pipelines/procurement/tenders/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/procurement/tenders/pipeline-spec.yaml
@@ -196,9 +196,7 @@ processed:
       parameters:
         types:
           end_date:
-            es:time-range: to
           start_date:
-            es:time-range: from
           description:
             es:title: true
           documents:

--- a/datapackage_pipelines_budgetkey/pipelines/supports/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/supports/pipeline-spec.yaml
@@ -232,7 +232,6 @@ by-request-year:
         types:
           support_title:
             es:title: true
-          year_requested:
 
     - run: join
       parameters:

--- a/datapackage_pipelines_budgetkey/pipelines/supports/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/supports/pipeline-spec.yaml
@@ -233,7 +233,6 @@ by-request-year:
           support_title:
             es:title: true
           year_requested:
-            es:time-range: year
 
     - run: join
       parameters:

--- a/datapackage_pipelines_budgetkey/processors/dump_to_es.py
+++ b/datapackage_pipelines_budgetkey/processors/dump_to_es.py
@@ -13,18 +13,18 @@ class BoostingMappingGenerator(MappingGenerator):
     @classmethod
     def _convert_type(cls, schema_type, field, prefix):
         prop = super(BoostingMappingGenerator, cls)._convert_type(schema_type, field, prefix)
-        if schema_type == 'string':
+        if field.get('es:keyword'):
+            prop['type'] = 'keyword'
+        elif schema_type == 'string':
             if field.get('es:title'):
                 prop['boost'] = 100
             if field.get('es:title') or field.get('es:hebrew'):
                 prop['fields'] = {
-                    "hebrew": { 
+                    "hebrew": {
                     "type": "text",
                     'analyzer': 'hebrew'
                 }
-          }
-        elif field.get('es:time-range'):
-            prop['index'] = True
+            }
         return prop
 
 


### PR DESCRIPTION
* removed es:time-range
* using the following attributes instead:
  * `__date_range_from` / `__date_range_to`
    * used to support search by range of dates
    * if missing from / to or both - uses default values of 1900 / 2100
  * `__date_range_months`
    * used to show count of items per month
    * array of `year-month` strings in the date range
      * missing from and to - empty array
      * missing from or to - array contains one element only (from / to)
      * year - contains all the months of the year
