### PR TITLE
109 Add Safety Orders information to construction companies

### DIFF
--- a/datapackage_pipelines_budgetkey/pipelines/entities/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/entities/pipeline-spec.yaml
@@ -183,6 +183,8 @@ entities:
   dependencies:
     - pipeline: ./procurement/spending/spending-by-entity
     - pipeline: ./supports/supports-by-entity
+    - pipeline: ./entities/safety-orders/safety-orders-by-entity
+
   pipeline:
     - run: add_metadata
       parameters:
@@ -260,6 +262,12 @@ entities:
             name: max_year
             aggregate: max
 
+    - run: load_resource
+      parameters:
+        url: /var/datapackages/entities/safety-orders/by-entity/datapackage.json
+        resource: safety-orders-by-entity
+
+
     # Load entities
     - run: load_resource
       parameters:
@@ -288,6 +296,23 @@ entities:
           received_amount_supports_alltime: null
           min_year: null
           max_year: null
+
+    # Load safety violations for every company
+    - run: join
+      parameters:
+        source:
+          name: safety-orders-by-entity
+          key:
+            - entity_id
+          delete: true
+        target:
+          name: entities
+          key:
+            - id
+          full: true
+        fields:
+          violations: null
+
 
     # Calculate score
     - run: calc-entity-score

--- a/datapackage_pipelines_budgetkey/pipelines/entities/safety-orders/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/entities/safety-orders/pipeline-spec.yaml
@@ -1,0 +1,94 @@
+safety-orders:
+  schedule:
+    crontab: 0 0 * * *
+  pipeline:
+    - run: add_metadata
+      parameters:
+        name: safety-orders
+        title: All Safety Orders
+    - run: add_resource
+      parameters:
+        url: http://employment.molsa.gov.il/Employment/SafetyAndHealth/Enforcement/Documents/צווי בטיחות.xlsx
+        name: safety-orders-recent
+    - run: add_resource
+      parameters:
+        url: http://employment.molsa.gov.il/Employment/SafetyAndHealth/Enforcement/Documents/orders.xlsx
+        name: safety-orders-old
+    - run: stream_remote_resources
+      parameters:
+        resources: "safety-orders-.+"
+    - run: concatenate
+      parameters:
+        target:
+          name: safety-orders
+        sources:  "safety-orders-.+"
+        fields:
+          date: ["ת. אישור צו"]
+          site: ["שם מפעל/אתר", "שם אתר"]
+          company_name: ["מבצע"]
+          violation: ["עבירה"]
+    - run: set_types
+      parameters:
+        resources: safety-orders
+        types:
+          date:
+            type: date
+            format: "%d/%m/%Y"
+    - run: fingerprint
+      parameters:
+        source-field: company_name
+        resource-name: safety-orders
+    - run: dump.to_path
+      parameters:
+        out-path: /var/datapackages/entities/safety-orders/all
+    - run: dump.to_sql
+      parameters:
+        tables:
+          safety_orders:
+            resource-name: safety-orders
+
+safety-orders-by-entity:
+  dependencies:
+   - pipeline: ./entities/safety-orders/safety-orders
+  pipeline:
+    - run: add_metadata
+      parameters:
+        name: safety-orders-by-entity
+        title: A list of all safety orders issued to each company
+    - run: load_resource
+      parameters:
+        url: dependency://./entities/safety-orders/safety-orders
+        resource: safety-orders
+    - run: concatenate
+      parameters:
+        target:
+          name: safety-orders-by-entity
+        sources:  safety-orders
+        fields:
+          entity_id: []
+          date: []
+          site: []
+          violation: []
+    - run: collate
+      parameters:
+        resource: safety-orders-by-entity
+        collated-field-name: violation-object
+        key:
+          - entity_id
+    - run: join
+      parameters:
+          source:
+            name: safety-orders-by-entity
+            key: ['entity_id']
+            delete: true
+          target:
+            name: safety-orders-by-entity
+            key: null
+          fields:
+            entity_id: null
+            violations:
+              name: violation-object
+              aggregate: array
+    - run: dump.to_path
+      parameters:
+        out-path: /var/datapackages/entities/safety-orders/by-entity


### PR DESCRIPTION
1) I found two links in the employment.molsa.gov.il site for two different lists. One list seems to hold old data and the second list data for 2017

2) I selected a daily schedule for the base pipeline. I could not see any clear indication if this data ever changes (both excel files are tiny with 1500 records in total)

3) I added the violations to the entities/entities pipeline (produces the entities/scored datapackage).

4) I did not add any tests. There are no tests to the entities/entities pipeline.
my entities/safety_orders does not contain any custom python code