### PR TITLE
Change it so that <number>{specialChar}<number> will not produce an empty fingerprint

### DIFF
--- a/datapackage_pipelines_budgetkey/processors/fingerprint.py
+++ b/datapackage_pipelines_budgetkey/processors/fingerprint.py
@@ -104,10 +104,11 @@ def calc_fingerprint(name):
         tgt = ENGLISH.sub('', tgt)
         options.append(tgt)
 
+        tgt = tgt.strip()
         if not tgt:
             tgt = options[0]
             for opt in reversed(options):
-                if opt:
+                if opt and opt.strip():
                     tgt = opt.strip()
                     break
         

--- a/tests/processors/fingerprint.py
+++ b/tests/processors/fingerprint.py
@@ -1,0 +1,55 @@
+from datapackage_pipelines_budgetkey.processors.fingerprint import calc_fingerprint
+
+
+def test_simple_text_stays_the_same():
+    assert calc_fingerprint("simple") == "simple"
+    assert calc_fingerprint("דניה סיבוס") == "דניה סיבוס"
+
+
+def test_extra_spaces():
+    assert calc_fingerprint("simple ") == calc_fingerprint("simple")
+    assert calc_fingerprint(" simple ") == calc_fingerprint("simple")
+
+
+def test_empty_input():
+    assert calc_fingerprint("") == "<empty>"
+    assert calc_fingerprint(" ") == "<empty>"
+
+
+def test_dashes():
+    assert calc_fingerprint("רמת גן") == calc_fingerprint("רמת-גן")
+
+
+def test_capital_case():
+    assert calc_fingerprint("Jerusalem") == calc_fingerprint("JERUSALEM")
+    assert calc_fingerprint("Jerusalem") == calc_fingerprint("jerusalem")
+
+
+def test_incorporated_suffix():
+    assert calc_fingerprint("דניה סיבוס") == calc_fingerprint("דניה סיבוס בעמ")
+    assert calc_fingerprint('דניה סיבוס') == calc_fingerprint('דניה סיבוס בע"מ')
+    assert calc_fingerprint('דניה סיבוס') == calc_fingerprint('דניה סיבוס בע"מ')
+    assert calc_fingerprint('דניה סיבוס') == calc_fingerprint("דניה סיבוס בע'מ")
+    assert calc_fingerprint("דניה סיבוס") == calc_fingerprint("דניה סיבוס - בעמ")
+
+
+def test_regional_council():
+    assert calc_fingerprint("מטה יהודה") == calc_fingerprint("מועצה אזורית מטה יהודה")
+    assert calc_fingerprint("מטה יהודה") == calc_fingerprint("מ.א. מטה יהודה")
+    assert calc_fingerprint("מטה יהודה") == calc_fingerprint('מוא"ז מטה יהודה')
+    assert calc_fingerprint("מטה יהודה") == calc_fingerprint("מועצה איזורית מטה יהודה")
+
+
+def test_city_council():
+    assert calc_fingerprint("ירושלים") == calc_fingerprint("עיריית ירושלים")
+    assert calc_fingerprint("ירושלים") == calc_fingerprint("עירית ירושלים")
+
+
+def test_all_numbers():
+    assert calc_fingerprint("334343") == "334343"
+
+
+
+def test_special_cases():
+    assert calc_fingerprint("מועדון חבר") == calc_fingerprint("מועדון")
+    assert calc_fingerprint("334343-334343") == "334343 334343"


### PR DESCRIPTION
I noticed that the fingerprint of {digit} pattern would return back the number
but {digit}-{digit} would be treated like an empty string. There is one entitiy with such a name and because it has the same fingerprint as an empty string it creates false matches

Also this improves the performance by looking at all partial suffixes once and avoid looking at all partial suffixes of partial suffixes