### PR TITLE
Bunch of changes to parse older notifications from maya

### DIFF
--- a/datapackage_pipelines_budgetkey/pipelines/people/appointments/maya/keep-only-updates.py
+++ b/datapackage_pipelines_budgetkey/pipelines/people/appointments/maya/keep-only-updates.py
@@ -18,7 +18,7 @@ def get_all_existing_ids():
     engine = create_engine(get_connection_string())
     ret = set()
     try:
-        rows = engine.execute("SELECT s3_object_name FROM maya_notification_list")
+        rows = engine.execute("SELECT s3_object_name FROM maya_notification_list where is_parse_error is not TRUE")
         ret = set([row['s3_object_name'] for row in rows])
     except (OperationalError, ProgrammingError):
         #ProgrammingError is for postgres and OperationError is on sqlite

--- a/datapackage_pipelines_budgetkey/pipelines/people/appointments/maya/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/people/appointments/maya/pipeline-spec.yaml
@@ -12,7 +12,7 @@ maya-notification-updates:
       runner: tzabar
       parameters:
         name: maya-notification-updates
-        from: '2016-01-01'
+        from: '2006-01-01'
     - run: keep-only-updates
     - run: store-nomination-to-s3
     - run: scrape-individual-nomination

--- a/datapackage_pipelines_budgetkey/pipelines/people/appointments/maya/scrape-individual-nomination.py
+++ b/datapackage_pipelines_budgetkey/pipelines/people/appointments/maya/scrape-individual-nomination.py
@@ -3,7 +3,7 @@ import requests
 
 from datapackage_pipelines.wrapper import process
 from datapackage_pipelines_budgetkey.common.object_storage import object_storage
-from datapackage_pipelines_budgetkey.pipelines.people.appointments.maya.maya_nomination_form import MayaForm
+from datapackage_pipelines_budgetkey.pipelines.people.appointments.maya.maya_nomination_form import MayaForm, ParseError
 
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -20,6 +20,8 @@ def modify_datapackage(datapackage, parameters, stats):
         {'name': 'notification_type', 'type':'string'},
         {'name': 'fix_for', 'type':'string'},
         {'name': 'is_nomination', 'type': 'boolean' },
+        {'name': 'is_parse_error', 'type': 'boolean'},
+
 
         #Specific to nominations
         {'name': 'start_date', 'type': 'date'},
@@ -40,7 +42,7 @@ def process_row(row, *_):
     try:
         row.update({
             'source': 'maya.tase.co.il',
-
+            'is_parse_error': False,
             'organisation_name': maya_form.company,
             'id': maya_form.id,
             'notification_type': maya_form.type,
@@ -60,8 +62,11 @@ def process_row(row, *_):
                 'gender': maya_form.gender,
                 'name': maya_form.full_name
             })
-    except ValueError as err:
-        raise ValueError("Failed to parse object {}".format(url)) from err
+    except ParseError as err:
+        logging.info("Failed to parse Maya Form {} with err {}".format(url, str(err.__cause__) if err.__cause__ else str(err)))
+        row.update({'is_parse_error': True})
+    except Exception as err:
+        raise RuntimeError('Parsing Failed Unexpectedly') from err
     return row
 
 process(process_row=process_row, modify_datapackage=modify_datapackage)


### PR DESCRIPTION
1. Parse errors no longer cause the process to crash (if there are strange formats I do not want it all to fail)
2. A new way to find the ID of the nomination which supports older files that have a different format
3. Replace the encoding detection code to a new scheme

==
NOTE: run the following SQL on postgresql:

DROP TABLE maya_notification_list