### PR TITLE
fix: run procurement in people pipeline

### DIFF
--- a/datapackage_pipelines_budgetkey/pipelines/people/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/people/pipeline-spec.yaml
@@ -26,6 +26,7 @@ all:
         url: dependency://./people/association_founders/association-founders
         resource: 0
 
+    -
       run: load_resource
       parameters:
         url: dependency://./people/procurement/procurement-individuals


### PR DESCRIPTION
turns out we didn't run `procurement-individuals` in the people pipeline.
Before this change the pipeline processed ~56000 rows
After this change the pipeline processed ~230000 rows.