### PR TITLE
fix(knesset_committee_decisions): paginate OData responses

### DIFF
--- a/datapackage_pipelines_budgetkey/pipelines/knesset/knesset_committee_decisions.py
+++ b/datapackage_pipelines_budgetkey/pipelines/knesset/knesset_committee_decisions.py
@@ -6,41 +6,70 @@ import dataflows as DF
 OUTPUT_PATH = '/var/datapackages/knesset/knesset_committee_decisions'
 os.makedirs(OUTPUT_PATH, exist_ok=True)
 
+
+def _odata_paged(url):
+    """Iterate every record from an OData v4 endpoint.
+
+    Knesset's OData v4 server returns at most 100 rows per response and
+    advertises the next page in `@odata.nextLink`. The previous version of
+    this pipeline ignored that link and consumed only the first 100 rows
+    of the global `KNS_DocumentCommitteeSession` query — which, ordered by
+    `Id`, are all from Knesset 18/20 (2016). The result was an `index.csv`
+    that froze in 2016 even though the live OData store now has 12.5M+
+    matching documents.
+    """
+    while url:
+        resp = requests.get(url).json()
+        for item in resp.get('value', []):
+            yield item
+        url = resp.get('@odata.nextLink')
+
+
 def flow(*_):
     out = []
     downloaded = 0
-    committees = requests.get('https://knesset.gov.il/OdataV4/ParliamentInfo/KNS_Committee?$filter=CommitteeTypeID%20eq%2070&$orderby=Name').json()
     committees = [
-        dict(
-            id=x['Id'],
-            knesset_num=x['KnessetNum'],
+        dict(id=x['Id'], knesset_num=x['KnessetNum'])
+        for x in _odata_paged(
+            'https://knesset.gov.il/OdataV4/ParliamentInfo/KNS_Committee'
+            '?$filter=CommitteeTypeID%20eq%2070&$orderby=Name'
         )
-        for x in committees['value']
     ]
     print(f'GOT {len(committees)} committees')
-    documents = requests.get(f'https://knesset.gov.il/OdataV4/ParliamentInfo/KNS_DocumentCommitteeSession?$filter=GroupTypeID%20eq%20106&$orderby=Id').json()
-    print(f'GOT {len(documents["value"])} documents')
+
     for committee in committees:
-        sessions = requests.get(f'https://knesset.gov.il/OdataV4/ParliamentInfo/KNS_CommitteeSession?$filter=CommitteeID%20eq%20{committee["id"]}&$orderby=Id').json()
-        print(f'GOT {len(sessions["value"])} sessions for committee {committee["id"]}')
-        for session in sessions['value']:
-            sessionID = session['Id']
-            # documents = requests.get(f'https://knesset.gov.il/OdataV4/ParliamentInfo/KNS_DocumentCommitteeSession?$filter=GroupTypeID%20eq%20106&$orderby=Id').json()
-            for document in documents['value']:
-                if document['ApplicationDesc'].lower() == 'pdf' and document['CommitteeSessionID'] == sessionID:
-                    doc = dict(
-                        url=document['FilePath'],
-                        filename=f'{document["Id"]}.pdf',
-                        date=document['LastUpdatedDate'],
-                        knesset_num=committee['knesset_num']
-                    )
-                    out.append(doc)
-                    outpath = os.path.join(OUTPUT_PATH, doc['filename'])
-                    if not os.path.exists(outpath):
-                        document = requests.get(doc['url'], stream=True)
-                        with open(outpath, 'wb') as o:
-                            shutil.copyfileobj(document.raw, o)
-                        downloaded += 1
+        sessions = list(_odata_paged(
+            'https://knesset.gov.il/OdataV4/ParliamentInfo/KNS_CommitteeSession'
+            f'?$filter=CommitteeID%20eq%20{committee["id"]}&$orderby=Id'
+        ))
+        print(f'GOT {len(sessions)} sessions for committee {committee["id"]}')
+        for session in sessions:
+            session_id = session['Id']
+            # Per-session, paginated document fetch. Pushing the
+            # `CommitteeSessionID eq …` predicate into OData keeps each
+            # response small (typically 0–3 PDFs per session) and lets us
+            # walk the entire history correctly.
+            documents = _odata_paged(
+                'https://knesset.gov.il/OdataV4/ParliamentInfo/KNS_DocumentCommitteeSession'
+                f'?$filter=CommitteeSessionID%20eq%20{session_id}'
+                '%20and%20GroupTypeID%20eq%20106&$orderby=Id'
+            )
+            for document in documents:
+                if document.get('ApplicationDesc', '').lower() != 'pdf':
+                    continue
+                doc = dict(
+                    url=document['FilePath'],
+                    filename=f'{document["Id"]}.pdf',
+                    date=document['LastUpdatedDate'],
+                    knesset_num=committee['knesset_num'],
+                )
+                out.append(doc)
+                outpath = os.path.join(OUTPUT_PATH, doc['filename'])
+                if not os.path.exists(outpath):
+                    pdf_resp = requests.get(doc['url'], stream=True)
+                    with open(outpath, 'wb') as o:
+                        shutil.copyfileobj(pdf_resp.raw, o)
+                    downloaded += 1
 
         print(f'DOWNLOADED {downloaded} out of {len(out)} total documents (now in committee {committee["id"]})')
 


### PR DESCRIPTION
## Summary

`pipelines/knesset/knesset_committee_decisions.py` calls
`KNS_DocumentCommitteeSession` once at the top of `flow()` and ignores
`@odata.nextLink`. OData v4 on `knesset.gov.il` paginates at 100 rows,
so the pipeline only ever sees the first 100 documents — sorted by
`Id` ascending those are all from 2016 (Knesset 18/20). The output
`index.csv` has been frozen at 7 records from 2016 since.

Live API today reports 12.5M+ matching documents and the most recent
`GroupTypeID=106` PDF is dated 2026-04-21. The data is there; the
pipeline just isn't reading it.

## What this PR does

- Adds an `_odata_paged()` helper that walks every `@odata.nextLink`.
- Replaces the global `KNS_DocumentCommitteeSession` fetch with a
  per-session paginated query (`CommitteeSessionID eq … and
  GroupTypeID eq 106`). Each per-session response is small (typically
  0–3 PDFs) and bounded.
- Also paginates `KNS_Committee` and `KNS_CommitteeSession` for
  consistency — the current dataset's committee/session counts are
  small enough today that they fit in 100 rows, but this prevents the
  same silent regression next year.
- Renames the inner `document` loop variable so it no longer shadows
  the outer dict (the previous code reassigned `document =
  requests.get(...)` mid-loop, which would have broken the next
  iteration's `document['ApplicationDesc']` access if that path had
  been reached more than once for the same dict).

## Smoke-test against live OData (no `dpp run` needed)

```python
# Per-session filter works:
session=2242368 Id=12594486 date=2026-04-21T09:06:13.71+03:00
session=2201184 Id=12577930 date=2026-04-20T11:04:11.54+03:00
session=2201184 Id=12577921 date=2026-04-20T11:02:13.193+03:00

# Pagination walks correctly:
committee 2024: walked 62 sessions across multiple pages
```

The first-page-only behavior of the existing code is reproducible by
just curling the OData URL — `$top` defaults to 100, response includes
`@odata.nextLink`, only documents 334231–341207 (all 2016) appear in
that first page when `$orderby=Id` ascending.

## Test plan

- [x] Live OData smoke (above) confirming the pagination + per-session
      filter work and find current data.
- [ ] Local `dpp run` and inspect that `index.csv` has thousands of
      rows spanning 2016 → 2026 instead of 7 from 2016.
- [ ] After merge + pipeline rebuild, confirm
      `next.obudget.org/datapackages/knesset/knesset_committee_decisions/datapackage.json`
      reports `count_of_rows > 7`.

## Why this matters downstream

`whiletrue-industries/rebuilding-bots` consumes
`next.obudget.org/datapackages/knesset/knesset_committee_decisions/index.csv`
to power one of the unified Parlibot's contexts. With the bug, the bot
has been answering committee-decision questions from a 7-row, 2016-only
corpus for the past several months. We just shipped a Layer-1 safety
rail there (refuses to overwrite local extraction CSVs when upstream
is empty / stale, alarms via SNS). This PR is Layer 2 — the actual
upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
