### PR TITLE
add a url discovery stage to the bundget change processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,14 @@ RUN chown dpp.dpp /datapackage_pipelines_budgetkey -R
 RUN pip install -e /
 # RUN pip install -U -r /requirements-dev.txt
 
-RUN apt-get install -y sudo unzip wget libglib2.0-0 && wget https://chromedriver.storage.googleapis.com/88.0.4324.96/chromedriver_linux64.zip && \
-    unzip chromedriver_linux64.zip && \
+# Fallback only: google_chrome.py resolves a chromedriver matching whatever
+# Chrome the google-chrome-in-a-box container reports, and only falls back to
+# this one if that lookup fails. Keep it roughly in step with that image.
+ARG CHROMEDRIVER_VERSION=150.0.7871.124
+RUN apt-get install -y sudo unzip wget libglib2.0-0 && \
+    wget -q "https://storage.googleapis.com/chrome-for-testing-public/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip" && \
+    unzip -j chromedriver-linux64.zip 'chromedriver-linux64/chromedriver' && \
+    rm chromedriver-linux64.zip && \
     chmod +x chromedriver && \
     mv chromedriver /usr/local/bin/ && \
     cp /certs/* /usr/local/share/ca-certificates/ && \

--- a/datapackage_pipelines_budgetkey/common/google_chrome.py
+++ b/datapackage_pipelines_budgetkey/common/google_chrome.py
@@ -1,20 +1,68 @@
 import paramiko
+import platform
 import random
+import stat
 import time
 import requests
 import socket
 import logging
+import io
 import json
 import os
 import shutil
 import tempfile
+import zipfile
 from selenium import webdriver
 import atexit
 
 
+CHROMEDRIVER_FEED = ('https://googlechromelabs.github.io/chrome-for-testing/'
+                     'latest-patch-versions-per-build-with-downloads.json')
+CHROMEDRIVER_CACHE = os.environ.get('CHROMEDRIVER_CACHE',
+                                    os.path.expanduser('~/.cache/chromedriver'))
+CHROMEDRIVER_FALLBACK = '/usr/local/bin/chromedriver'
+
+
+def _chromedriver_platform():
+    system, machine = platform.system(), platform.machine()
+    if system == 'Darwin':
+        return 'mac-arm64' if machine == 'arm64' else 'mac-x64'
+    return 'linux64'
+
+
+def resolve_chromedriver(browser_version, fallback=CHROMEDRIVER_FALLBACK):
+    """Fetch a chromedriver matching the Chrome inside the container.
+
+    chromedriver only drives a browser of its own major version, and the
+    browser lives in a separately built image (google-chrome-in-a-box) which
+    updates on its own schedule -- so a chromedriver baked in at build time
+    goes stale the moment either image is rebuilt. Resolving against the
+    version the container actually reports keeps the two in step.
+    """
+    try:
+        build = '.'.join(browser_version.split('.')[:3])
+        entry = requests.get(CHROMEDRIVER_FEED, timeout=60).json()['builds'][build]
+        target = os.path.join(CHROMEDRIVER_CACHE, entry['version'], 'chromedriver')
+        if not os.path.exists(target):
+            url = next(d['url'] for d in entry['downloads']['chromedriver']
+                       if d['platform'] == _chromedriver_platform())
+            archive = zipfile.ZipFile(io.BytesIO(requests.get(url, timeout=300).content))
+            member = next(n for n in archive.namelist() if n.endswith('/chromedriver'))
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with archive.open(member) as src, open(target, 'wb') as out:
+                shutil.copyfileobj(src, out)
+            os.chmod(target, os.stat(target).st_mode | stat.S_IEXEC)
+        logging.info('USING CHROMEDRIVER %s for Chrome %s', entry['version'], browser_version)
+        return target
+    except Exception:
+        logging.exception('Failed to resolve a chromedriver for Chrome %s, falling back to %s',
+                          browser_version, fallback)
+        return fallback
+
+
 class google_chrome_driver():
 
-    def __init__(self, wait=True, initial='https://data.gov.il', chromedriver='/usr/local/bin/chromedriver'):
+    def __init__(self, wait=True, initial='https://data.gov.il', chromedriver=None):
         if wait:
             time.sleep(random.randint(1, 600))
         self.hostname = 'tzabar.obudget.org'
@@ -43,7 +91,7 @@ class google_chrome_driver():
             logging.info('COUNTED %d running containers, waiting', running)
             time.sleep(60)
 
-        cmd = f'docker run -p {self.port}:{self.port} -p {self.port+1}:{self.port+1} --add-host stats.tehila.gov.il:127.0.0.1 -d akariv/google-chrome-in-a-box {self.port} {self.port+1} {initial}'
+        cmd = f'docker run -p {self.port}:{self.port} -p {self.port+1}:{self.port+1} --add-host stats.tehila.gov.il:127.0.0.1 -d ghcr.io/whiletrue-industries/google-chrome-in-a-box {self.port} {self.port+1} {initial}'
         stdin, stdout, stderr = self.client.exec_command(cmd)
 
         while not self.docker_container:
@@ -63,7 +111,13 @@ class google_chrome_driver():
                 except Exception as e:
                     logging.error('Waiting %s (%s): %s', i, windows, e)
 
+            if chromedriver is None:
+                version = requests.get(f'http://{self.hostname_ip}:{self.port}/json/version').json()
+                chromedriver = resolve_chromedriver(version['Browser'].split('/')[-1])
+
             chrome_options = webdriver.ChromeOptions()
+            # By IP, not hostname: Chrome rejects devtools requests whose Host
+            # header is neither localhost nor an IP address.
             chrome_options.debugger_address = f'{self.hostname_ip}:{self.port}'
             self.driver = webdriver.Chrome(chromedriver, options=chrome_options)
         except Exception:

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/current_year_urls.py
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/current_year_urls.py
@@ -1,0 +1,63 @@
+import logging
+
+import requests
+from pyquery import PyQuery as pq
+
+from datapackage_pipelines_budgetkey.common.google_chrome import google_chrome_driver
+
+# The gov.il "current year budget changes" page links to the data/explanation
+# files with a weekly update date baked into each filename (e.g.
+# BudgetChanges_approv_data_16072026.csv), so the URLs change over time and have
+# to be rediscovered from the page on every run instead of being hardcoded.
+# Same content-page API used by procurement/calls_for_bids/class_action.py, with
+# the requests->browser fallback from procurement/spending/collect_report_uris.py
+# (the content API is behind Cloudflare, so plain requests are often blocked).
+URL = 'https://www.gov.il/ContentPageWebApi/api/content-pages/' \
+      'budget-changes-current-year?culture=he'
+
+HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) '
+                  'Gecko/20100101 Firefox/153.0'
+}
+
+# Substrings identifying each file among the page's links. 'approv' = approved
+# changes, 'vaada' = pending changes (on the finance committee's table).
+FILE_KEYS = ['approv_data', 'approv_explain', 'vaada_data', 'vaada_explain']
+
+
+def get_page():
+    try:
+        resp = requests.get(URL, headers=HEADERS, timeout=120)
+        assert resp.status_code == 200, resp.status_code
+        assert 'html' not in resp.headers.get('content-type', '').lower()
+        return resp.json()
+    except Exception as e:
+        logging.warning('Failed to fetch %s via requests (%s), trying google chrome', URL, e)
+        gcd = google_chrome_driver(initial=URL, wait=False)
+        try:
+            return gcd.json(URL)
+        finally:
+            gcd.teardown()
+
+
+def get_current_year_urls():
+    """Discover the current-year file URLs. Returns {file_key: url}."""
+    page = get_page()
+    links = pq(page['contentMain']['htmlContents'][0]['sectionData']).find('a')
+    urls = [pq(a).attr('href') for a in links]
+    urls = [u for u in urls if u]
+    result = {}
+    for key in FILE_KEYS:
+        for u in urls:
+            if key in u:
+                result[key] = u
+                break
+    missing = [k for k in FILE_KEYS if k not in result]
+    assert not missing, \
+        'Could not find current-year files %r on page; found links: %r' % (missing, urls)
+    logging.info('Discovered current-year budget-change URLs: %r', result)
+    return result
+
+
+if __name__ == '__main__':
+    print(get_current_year_urls())

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/current_year_urls.py
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/current_year_urls.py
@@ -12,8 +12,7 @@ from datapackage_pipelines_budgetkey.common.google_chrome import google_chrome_d
 # Same content-page API used by procurement/calls_for_bids/class_action.py, with
 # the requests->browser fallback from procurement/spending/collect_report_uris.py
 # (the content API is behind Cloudflare, so plain requests are often blocked).
-URL = 'https://www.gov.il/ContentPageWebApi/api/content-pages/' \
-      'budget-changes-current-year?culture=he'
+URL = 'https://www.gov.il/he/pages/budget-changes-current-year'
 
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) '
@@ -24,18 +23,23 @@ HEADERS = {
 # changes, 'vaada' = pending changes (on the finance committee's table).
 FILE_KEYS = ['approv_data', 'approv_explain', 'vaada_data', 'vaada_explain']
 
+def test_page(page):
+    assert 'שינויים בתקציב לשנה השוטפת המונחים על שולחן ועדת הכספים של הכנסת' in page, \
+        'Page content does not contain expected text'
 
 def get_page():
     try:
         resp = requests.get(URL, headers=HEADERS, timeout=120)
         assert resp.status_code == 200, resp.status_code
-        assert 'html' not in resp.headers.get('content-type', '').lower()
-        return resp.json()
+        resp_text = resp.text
+        return resp_text
     except Exception as e:
         logging.warning('Failed to fetch %s via requests (%s), trying google chrome', URL, e)
         gcd = google_chrome_driver(initial=URL, wait=False)
         try:
-            return gcd.json(URL)
+            gcd.driver.get(URL)
+            page = gcd.driver.page_source
+            return page
         finally:
             gcd.teardown()
 
@@ -43,7 +47,8 @@ def get_page():
 def get_current_year_urls():
     """Discover the current-year file URLs. Returns {file_key: url}."""
     page = get_page()
-    links = pq(page['contentMain']['htmlContents'][0]['sectionData']).find('a')
+    test_page(page)
+    links = pq(page).find('a')
     urls = [pq(a).attr('href') for a in links]
     urls = [u for u in urls if u]
     result = {}

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/explanations/explanation_fetcher.py
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/explanations/explanation_fetcher.py
@@ -12,6 +12,8 @@ from datapackage_pipelines.utilities.resources import PROP_STREAMING
 from textract.parsers.doc_parser import Parser
 from datapackage_pipelines.wrapper import ingest, spew
 from datapackage_pipelines_budgetkey.common.google_chrome import google_chrome_driver
+from datapackage_pipelines_budgetkey.pipelines.budget.national.changes.current_year_urls \
+    import get_current_year_urls
 
 parameters, dp, res_iter = ingest()
 
@@ -82,4 +84,6 @@ schema = {
 resource['schema'] = schema
 dp['resources'].append(resource)
 
-spew(dp, itertools.chain(res_iter, [get_explanations(parameters['url'])]))
+url = parameters.get('url') or get_current_year_urls()[parameters['file_key']]
+
+spew(dp, itertools.chain(res_iter, [get_explanations(url)]))

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/explanations/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/explanations/pipeline-spec.yaml
@@ -70,13 +70,13 @@ all:
         resource:
           name: explanation-2026
           path: data/explanation-2026.csv
-        url: https://www.gov.il/files/mof/Budgetchanges/approv_explain.zip
+        file_key: approv_explain
     - run: explanation_fetcher
       parameters:
         resource:
           name: explanation-pending
           path: data/explanation-pending.csv
-        url: https://www.gov.il/files/mof/Budgetchanges/vaada_explain.zip
+        file_key: vaada_explain
     - run: explanation_extractor
       parameters:
         resource:

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/original/current_year.py
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/original/current_year.py
@@ -1,0 +1,39 @@
+import dataflows as DF
+
+from datapackage_pipelines.utilities.resources import PROP_STREAMING
+from datapackage_pipelines_budgetkey.processors.resource_without_excel_formulas_lib \
+    import iter_resource_without_excel_formulas
+from datapackage_pipelines_budgetkey.pipelines.budget.national.changes.current_year_urls \
+    import get_current_year_urls
+
+# (resource name, discovered-url key) for the current-year data files. The URLs
+# are discovered from the gov.il page (see current_year_urls.py) rather than
+# hardcoded, since they carry a weekly-changing date.
+SOURCES = [
+    ('changes_2026', 'approv_data'),
+    ('pending_changes_2026', 'vaada_data'),
+]
+
+TABULATOR = {'encoding': 'windows-1255', 'headers': 4}
+
+
+def data_resource(name, url):
+    headers, rows = iter_resource_without_excel_formulas(url, {'tabulator': TABULATOR})
+    schema = {'fields': [{'name': h, 'type': 'string'} for h in headers]}
+    return rows, DF.update_resource(
+        -1, name=name, path='data/%s.csv' % name, schema=schema, **{PROP_STREAMING: True}
+    )
+
+
+def flow(*_):
+    urls = get_current_year_urls()
+    steps = []
+    for name, key in SOURCES:
+        rows, update = data_resource(name, urls[key])
+        steps.append(rows)
+        steps.append(update)
+    return DF.Flow(*steps)
+
+
+if __name__ == '__main__':
+    DF.Flow(flow(), DF.printer()).process()

--- a/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/original/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/budget/national/changes/original/pipeline-spec.yaml
@@ -169,28 +169,8 @@ national-budget-changes:
         tabulator:
           encoding: windows-1255
           headers: 4
-    - run: resource_without_excel_formulas
-      # ruginner: tzabar
-      parameters:
-        # url: https://budgetkey-files.ams3.digitaloceanspaces.com/yearly-budgets/approv_data.csv
-        url: https://www.gov.il/files/mof/Budgetchanges/approv_data.csv
-        resource:
-          name: changes_2026
-          path: data/changes_2026.csv
-        tabulator:
-          encoding: windows-1255
-          headers: 4
-    - run: resource_without_excel_formulas
-      # runner: tzabar
-      parameters:
-        # url: https://budgetkey-files.ams3.digitaloceanspaces.com/yearly-budgets/vaada_data.csv
-        url: https://www.gov.il/files/mof/Budgetchanges/vaada_data.csv
-        resource:
-          name: pending_changes_2026
-          path: data/pending_changes_2026.csv
-        tabulator:
-          encoding: windows-1255
-          headers: 4
+    - flow: current_year
+      runner: tzabar
     - run: set_pending
       parameters:
         pending-resource-name: pending_changes_2026

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(
     install_requires=['pyquery',
                     #   'demjson',
                       'requests',
-                      'selenium<4.3',
+                      'selenium<4.3',  # 4.3 removed find_element_by_*, used across the scrapers,
+                                       # and 4.10 removed the positional executable_path argument
+
                       'fuzzywuzzy[speedup]',
                       'plyvel',
                       'filemagic',


### PR DESCRIPTION
The budget changes are now published on a changing link. In order to get that link we must parse [the json of the page](https://openapi-gc.digital.gov.il/pub/cio/govil/rest/contentpage/v1/api/content-pages/budget-changes-current-year?culture=he) but that json is only available to "real" browsers. This should run in the production environment, I checked against a JSON I downloaded but could not get the `get_current_year_urls` call to work locally.