### PR TITLE
Fix SQLAlchemy 2.0 incompatibilities in raw execute() calls

### DIFF
--- a/datapackage_pipelines_budgetkey/pipelines/budgetkey/elasticsearch/activity_fetch_extra_data.py
+++ b/datapackage_pipelines_budgetkey/pipelines/budgetkey/elasticsearch/activity_fetch_extra_data.py
@@ -37,9 +37,9 @@ def expand_mappings(mappings):
     with engine.connect() as conn:
         for mapping in mappings:
             TITLE_QUERY = text('SELECT title from raw_budget where code=:code and year=:year')
-            mapping['title'] = conn.execute(TITLE_QUERY, **mapping).fetchone().title
+            mapping['title'] = conn.execute(TITLE_QUERY, mapping).fetchone().title
             ITEMS_QUERY = text('SELECT year, code, title, net_allocated, net_revised, net_executed from raw_budget where code=:code and title=:title and net_revised > 0')
-            for r in conn.execute(ITEMS_QUERY, **mapping).fetchall():
+            for r in conn.execute(ITEMS_QUERY, mapping).fetchall():
                 ret.append(dict(
                     code=r.code,
                     year=r.year,
@@ -70,7 +70,7 @@ def fetch_spending(budget_code):
                WHERE budget_code=:code
                ORDER BY volume desc nulls last
     ''')
-    return [r._asdict() for r in engine.connect().execute(SPENDING, code=budget_code).fetchall()]
+    return [r._asdict() for r in engine.connect().execute(SPENDING, dict(code=budget_code)).fetchall()]
 
 
 def fetch_tenders(**kw):
@@ -84,7 +84,7 @@ def fetch_tenders(**kw):
         FROM procurement_tenders_processed
         WHERE publication_id=:publication_id AND tender_id=:tender_id AND tender_type=:tender_type
     ''')
-    return dict(engine.connect().execute(TENDER, **kw).fetchone())
+    return engine.connect().execute(TENDER, kw).fetchone()._asdict()
 
 def format_date(x):
     if x:

--- a/datapackage_pipelines_budgetkey/processors/filter_updated_items.py
+++ b/datapackage_pipelines_budgetkey/processors/filter_updated_items.py
@@ -28,7 +28,7 @@ def filter_resource(rows, stmt, k_fields, v_fields):
             v_values = [row[v] for v in v_fields]
             if any(v in (None, '') for v in v_values):
                 continue
-            db_values = conn.execute(stmt, **params).first()
+            db_values = conn.execute(stmt, params).first()
             if db_values:
                 if all((db_value == v_value)
                        for db_value, v_value

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ setup(
                       'elasticsearch<9.0.0',
                       'openai',
                       'kvfile>=1.1.2',
-                      'pyproj'
+                      'pyproj',
+                      'sqlalchemy<3',  # pulled in transitively via dataflows-tabulator, which only
+                                       # requires >=0.9.6 - pin so the next major can't arrive
+                                       # unannounced with the base image
 		     ],
     extras_require={'develop': ["tox", "datapackage-pipelines"]},
     entry_points={'console_scripts': ['budgetkey-dpp = datapackage_pipelines_budgetkey.cli:main']}


### PR DESCRIPTION
## Problem

`filter_updated_items` has been failing on every row with:

```
TypeError: execute() got an unexpected keyword argument 'transaction_id'
```

`Connection.execute()` dropped bind parameters passed as **keyword arguments** in SQLAlchemy 2.0 (deprecated in 1.4). The signature is now `execute(statement, parameters=None, *, execution_options=None)`, so `**params` gets matched against that signature and the first key that isn't a real argument name blows up.

The `except Exception: logging.exception(...)` in `filter_resource` swallowed it per row, so instead of crashing the processor logged a traceback per row and silently yielded nothing.

## Scope

Five call sites, not four — `activity_fetch_extra_data.py:73` passes `code=budget_code` as a plain kwarg and doesn't match a `**` grep:

| File:line | Change |
|---|---|
| `filter_updated_items.py:31` | `execute(stmt, params)` |
| `activity_fetch_extra_data.py:40` | `execute(TITLE_QUERY, mapping)` |
| `activity_fetch_extra_data.py:42` | `execute(ITEMS_QUERY, mapping)` |
| `activity_fetch_extra_data.py:73` | `execute(SPENDING, dict(code=budget_code))` |
| `activity_fetch_extra_data.py:87` | `execute(TENDER, kw)` |

`fetch_tenders` had a **second** 2.0 breakage on the same line: `dict(Row)`, which no longer works now that `Row` isn't a mapping. It would have failed immediately after the param fix, so it's changed to `Row._asdict()`, matching `fetch_spending` above it.

## Pin

SQLAlchemy isn't declared by this repo at all — it arrives transitively via `dataflows` → `dataflows-tabulator` (`sqlalchemy>=0.9.6`) and is already installed in `ghcr.io/whiletrue-industries/datapackage-pipelines:latest-slim` before `pip install -e /` runs. Build logs show `2.0.19` through 2026-07-04 and `2.0.51` from 2026-07-06 on; logs older than ~90 days have expired, so the 1.x → 2.x crossing isn't visible, but that's what actually broke this. Added `sqlalchemy<3` to `install_requires` so the next major can't land unannounced with a base image rebuild.

## Verification

No `psycopg2` in the local venv, so the semantics were checked against in-memory SQLite on the same 2.0.51 — the binding behaviour and `Row` API are core-level, not dialect-specific:

```
1 exact-keys : ('0020460242', 2019, 'קדם עתידים')
2 extra-keys : ('0020460242', 2019, 'קדם עתידים')   <- `part` not in SQL, ignored cleanly
3 _asdict    : {'code': ..., 'year': 2019, 'title': ...}
4 kwargs     : TypeError: execute() got an unexpected keyword argument 'code'
5 dict(Row)  : ValueError: dictionary update sequence element #0 has length 10; 2 is required
```

Case 2 is the one that mattered: `expand_mappings` passes a dict containing `part`, which no query binds. Extra keys are ignored for `text()` constructs, so the mapping can be passed wholesale.

⚠️ Nothing in `tests/` covers either module and the queries themselves are unchanged, so this is syntax-checked and verified against SQLite, **not** exercised against Postgres. Real confirmation is the next pipeline run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)