### PR TITLE
Mark suppliers of inactive social services as inactive

### DIFF
--- a/datapackage_pipelines_budgetkey/pipelines/activities/social_services/pipeline-spec.yaml
+++ b/datapackage_pipelines_budgetkey/pipelines/activities/social_services/pipeline-spec.yaml
@@ -8,7 +8,7 @@ social_services:
       parameters:
         name: social_services
         title: Fetch social services from data input
-        revision: '2026-08-04.01'
+        revision: '2026-08-04.02'
     - flow: social_services
 
 social_service_suppliers:

--- a/datapackage_pipelines_budgetkey/pipelines/activities/social_services/social_services.py
+++ b/datapackage_pipelines_budgetkey/pipelines/activities/social_services/social_services.py
@@ -126,6 +126,9 @@ def fix_suppliers():
         eids_municipality = set()
         geos = set()
         actual_suppliers = []
+        service_end_year = row['max_activity_year']
+        service_end_year = int(service_end_year) if service_end_year is not None else None
+        service_inactive = service_end_year is not None and service_end_year < CURRENT_YEAR
         for v in suppliers:
             for f in ['entity_id', 'entity_name']:
                 if v.get(f):
@@ -133,6 +136,13 @@ def fix_suppliers():
             for f in ('year_activity_start', 'year_activity_end'):
                 if f in v and not v[f]:
                     del v[f]
+            # counted below as it was when the service was last active
+            counted = v.get('year_activity_end') is None
+            if service_inactive:
+                # the service itself stopped being active, so no supplier can still be operating it
+                supplier_end_year = v.get('year_activity_end')
+                v['year_activity_end'] = service_end_year if supplier_end_year is None else min(int(supplier_end_year), service_end_year)
+                v['active'] = 'no'
             start_year = v.get('year_activity_start') or 2020
             start_year = max(start_year, row['min_activity_year'] or start_year)
             end_year = v.get('year_activity_end') or CURRENT_YEAR
@@ -142,7 +152,7 @@ def fix_suppliers():
                 continue
             actual_suppliers.append(v)
             v['geo'] = [geo[i] for i in v.get('geo', [])]
-            if v.get('year_activity_end') is None: # still active, so counted
+            if counted: # was active when the service was last active, so counted
                 geos.update(v['geo'])
                 eid = v['entity_id']
                 eids.add(eid)

--- a/datapackage_pipelines_budgetkey/pipelines/activities/social_services/social_services.py
+++ b/datapackage_pipelines_budgetkey/pipelines/activities/social_services/social_services.py
@@ -128,7 +128,8 @@ def fix_suppliers():
         actual_suppliers = []
         service_end_year = row['max_activity_year']
         service_end_year = int(service_end_year) if service_end_year is not None else None
-        service_inactive = service_end_year is not None and service_end_year < CURRENT_YEAR
+        # a service with no budget records at all has no known end year to propagate
+        service_inactive = not row['currently_active'] and service_end_year is not None
         for v in suppliers:
             for f in ['entity_id', 'entity_name']:
                 if v.get(f):


### PR DESCRIPTION
## Problem

A social service can end up inactive — its budget records only cover years X..Y where Y is not the current year — while its suppliers are still marked as active (`active: 'yes'`, no `year_activity_end`). The service page then shows operators that supposedly still run a service that no longer exists.

Against the current data-input contents this affects **97 services / ~590 supplier records**.

## Fix

In `fix_suppliers()`, a service counts as inactive when it is not `currently_active` (the flag already computed by `add_current_budget()`) and it has a known `max_activity_year`. For such services every supplier gets:

- `year_activity_end` set to the service's last activity year (suppliers that already ended earlier keep their own, earlier, end year — we take the `min`)
- `active` set to `'no'`

Services with no budget records at all are `currently_active=False` too, but have no end year to propagate, so they are left alone.

`activity_years` was already capped by `max_activity_year`, so it is unchanged.

## Counts

`supplier_count`, `supplier_count_company/association/municipality`, `supplier_kinds` and `geo_coverage` count "still active" suppliers. They are now computed from the activeness *before* the fix, so an inactive service keeps showing the suppliers it had in its last active year instead of dropping to 0.

## Verification

Ran the flow (`services` → `add_current_budget` → `fix_suppliers`) against live data-input data, before and after:

- 414 services total
- 97 changed — all of them `currently_active=False`
- **0** changes to currently-active services
- **0** changes to supplier counts / kinds / geo coverage

Example (`byt-myty`, `max_activity_year=2024`):
- before: `["580036945", "yes", null, [2023, 2024]]`
- after: `["580036945", "no", 2024, [2023, 2024]]`

Pipeline revision bumped so the pipeline re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)